### PR TITLE
Change the adress in prefrences dialog to github

### DIFF
--- a/ts/qlipper.cs.ts
+++ b/ts/qlipper.cs.ts
@@ -263,7 +263,7 @@
     </message>
     <message>
         <location filename="../src/qlippersystray.cpp" line="133"/>
-        <source>Lightweight, cross-platform clipboard history applet.&lt;p&gt;(c)&amp;nbsp;2010-2011&amp;nbsp;Petr&amp;nbsp;Vanek&amp;nbsp;&amp;lt;petr@scribus.info&amp;gt;&lt;p&gt;&lt;a href=&quot;http://code.google.com/p/qlipper/&quot;&gt;http://code.google.com/p/qlipper/&lt;/a&gt;&lt;p&gt;Support for global keyboard shortcut: %1&lt;br&gt;Support for network clipboard sharing: %2</source>
+        <source>Lightweight, cross-platform clipboard history applet.&lt;p&gt;(c)&amp;nbsp;2010-2011&amp;nbsp;Petr&amp;nbsp;Vanek&amp;nbsp;&amp;lt;petr@scribus.info&amp;gt;&lt;p&gt;&lt;a href=&quot;https://github.com/pvanek/qlipper/&quot;&gt;https://github.com/pvanek/qlipper/&lt;/a&gt;&lt;p&gt;Support for global keyboard shortcut: %1&lt;br&gt;Support for network clipboard sharing: %2</source>
         <translation>Odlehčení, multiplatformní správce systémové schránky.&lt;p&gt;(c)&amp;nbsp;2010-2011&amp;nbsp;Petr&amp;nbsp;Vanek&amp;nbsp;&amp;lt;petr@scribus.info&amp;gt;&lt;p&gt;&lt;a href=&quot;http://code.google.com/p/qlipper/&quot;&gt;http://code.google.com/p/qlipper/&lt;/a&gt;&lt;p&gt;Podpora pro globální klávesové zkratky: %1&lt;br&gt;Podpora pro sdílení schránky po síti: %2</translation>
     </message>
 </context>

--- a/ts/qlipper.sr.ts
+++ b/ts/qlipper.sr.ts
@@ -263,7 +263,7 @@
     </message>
     <message>
         <location filename="../src/qlippersystray.cpp" line="133"/>
-        <source>Lightweight, cross-platform clipboard history applet.&lt;p&gt;(c)&amp;nbsp;2010-2011&amp;nbsp;Petr&amp;nbsp;Vanek&amp;nbsp;&amp;lt;petr@scribus.info&amp;gt;&lt;p&gt;&lt;a href=&quot;http://code.google.com/p/qlipper/&quot;&gt;http://code.google.com/p/qlipper/&lt;/a&gt;&lt;p&gt;Support for global keyboard shortcut: %1&lt;br&gt;Support for network clipboard sharing: %2</source>
+        <source>Lightweight, cross-platform clipboard history applet.&lt;p&gt;(c)&amp;nbsp;2010-2011&amp;nbsp;Petr&amp;nbsp;Vanek&amp;nbsp;&amp;lt;petr@scribus.info&amp;gt;&lt;p&gt;&lt;a href=&quot;https://github.com/pvanek/qlipper/&quot;&gt;https://github.com/pvanek/qlipper/&lt;/a&gt;&lt;p&gt;Support for global keyboard shortcut: %1&lt;br&gt;Support for network clipboard sharing: %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Since google code is shutting down and this is now managed on github in the about Qlipper in the tray icon.