### PR TITLE
use QClipboard wrapper to fix multiple issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set (QLIPPER_HEADERS
     src/qlipperpreferencesdialog.h
     src/qlippersystray.h
     src/qlippernetwork.h
+    src/clipboardwrap.h
 )
 set (QLIPPER_SOURCES 
     qkeysequencewidget/qkeysequencewidget.cpp
@@ -103,6 +104,7 @@ set (QLIPPER_SOURCES
     src/qlipperpreferencesdialog.cpp
     src/qlippersystray.cpp
     src/qlippernetwork.cpp
+    src/clipboardwrap.cpp
 )
 
 if (NOT QXT_FOUND)

--- a/src/clipboardwrap.cpp
+++ b/src/clipboardwrap.cpp
@@ -1,0 +1,91 @@
+/*
+Qlipper - clipboard history manager
+Copyright (C) 2015 Palo Kisa <palo.kisa@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "clipboardwrap.h"
+
+#include <QApplication>
+#include <QTimer>
+#include <QDebug>
+
+QScopedPointer<ClipboardWrap> ClipboardWrap::m_instance(0);
+
+namespace
+{
+    class WorkGuard
+    {
+    public:
+        WorkGuard(bool & guard)
+            : mGuard(guard)
+        {
+            mGuard = false;
+        }
+        ~WorkGuard()
+        {
+            mGuard = true;
+        }
+    private:
+        bool & mGuard;
+    };
+}
+
+ClipboardWrap * ClipboardWrap::Instance()
+{
+    //instance can't be created in static initilization time because QApplication object doesn't exist in that time
+    if (m_instance.isNull())
+        m_instance.reset(new ClipboardWrap);
+    return m_instance.data();
+}
+
+ClipboardWrap::ClipboardWrap()
+    : m_clip(QApplication::clipboard())
+    , m_shouldEmit(true)
+    , m_timer(new QTimer)
+{
+    connect(m_clip, &QClipboard::changed, this, &ClipboardWrap::onChanged);
+    connect(m_timer.data(), &QTimer::timeout, this, &ClipboardWrap::emitChanged);
+
+    //Note: the timer is here as a workaround for signal flood for primary selection
+    //      from GTK apps
+    m_timer->setInterval(0);
+    m_timer->setSingleShot(true);
+}
+
+ClipboardWrap::~ClipboardWrap()
+{
+}
+
+void ClipboardWrap::emitChanged()
+{
+    emit changed(m_change);
+}
+
+void ClipboardWrap::onChanged(QClipboard::Mode mode)
+{
+    if (m_shouldEmit)
+    {
+        m_change = mode;
+        m_timer->start();
+    }
+}
+
+void ClipboardWrap::setMimeData(QMimeData * src, QClipboard::Mode mode)
+{
+    WorkGuard g(m_shouldEmit);
+    return m_clip->setMimeData(src, mode);
+}

--- a/src/clipboardwrap.h
+++ b/src/clipboardwrap.h
@@ -1,0 +1,59 @@
+/*
+Qlipper - clipboard history manager
+Copyright (C) 2015 Palo Kisa <palo.kisa@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef CLIPBOARDWRAP_H
+#define CLIPBOARDWRAP_H
+
+#include <QClipboard>
+#include <QScopedPointer>
+
+class QTimer;
+
+class ClipboardWrap : public QObject
+{
+    Q_OBJECT
+
+    class Creator;
+    friend class Creator;
+
+public:
+    static ClipboardWrap *Instance();
+    ~ClipboardWrap();
+
+    void setMimeData(QMimeData * src, QClipboard::Mode mode = QClipboard::Clipboard);
+
+signals:
+    void changed(QClipboard::Mode mode);
+
+private slots:
+    void onChanged(QClipboard::Mode mode);
+    void emitChanged();
+
+private:
+    ClipboardWrap();
+
+    static QScopedPointer<ClipboardWrap> m_instance;
+
+    QClipboard * m_clip;
+    bool m_shouldEmit;
+    QClipboard::Mode m_change;
+    QScopedPointer<QTimer> m_timer;
+};
+
+#endif // CLIPBOARDWRAP_H

--- a/src/qlipperitem.cpp
+++ b/src/qlipperitem.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "qlipperpreferences.h"
 #include "qlipperitem.h"
+#include "clipboardwrap.h"
 
 
 QlipperItem::QlipperItem()
@@ -119,9 +120,9 @@ QClipboard::Mode QlipperItem::clipBoardMode() const
     return m_mode;
 }
 
-void QlipperItem::toClipboard() const
+void QlipperItem::toClipboard(bool synchronize) const
 {
-    QClipboard * clipboard = QApplication::clipboard();
+    ClipboardWrap * clipboard = ClipboardWrap::Instance();
 
     QMimeData *mime = new QMimeData();
 
@@ -131,9 +132,8 @@ void QlipperItem::toClipboard() const
         it.next();
         mime->setData(it.key(), it.value());
     }
-
     clipboard->setMimeData(mime, m_mode);
-    if (QlipperPreferences::Instance()->shouldSynchronizeClipboards())
+    if (synchronize && QlipperPreferences::Instance()->shouldSynchronizeClipboards())
         clipboard->setMimeData(mime, QClipboard::Clipboard == m_mode ? QClipboard::Selection : QClipboard::Clipboard);
 }
 

--- a/src/qlipperitem.h
+++ b/src/qlipperitem.h
@@ -50,7 +50,7 @@ public:
     bool isValid() const { return m_valid; }
     bool enforceHistory() const { return m_enforceHistory; }
 
-    void toClipboard() const;
+    void toClipboard(bool synchronize) const;
 
     QString displayRole() const;
     QIcon decorationRole() const;

--- a/src/qlippermodel.h
+++ b/src/qlippermodel.h
@@ -51,7 +51,6 @@ protected:
 private:
     QList<QlipperItem> m_sticky;
     QList<QlipperItem> m_dynamic;
-    QClipboard *m_clipboard;
     QlipperItem m_currentItem;
     QlipperNetwork *m_network;
 


### PR DESCRIPTION
1. do not handle signals emitted upon our activity (setting the clipboard contents)
2. add slight delay for signal processing to avoid signal flood and getting messed content upon GTK applications selection changes

fixes #22