### PR TITLE
qlipperitem: Handle different type as equal

### DIFF
--- a/src/qlipperitem.cpp
+++ b/src/qlipperitem.cpp
@@ -255,8 +255,11 @@ QString QlipperItem::tooltipRole() const
 
 bool QlipperItem::operator==(const QlipperItem &other) const {
     // do not check contentType here as we need to compare sticky vs. rest of the world
+    // Note2: If we're synchronizing clipboards, clipboard type/mode don't need to match
     return this->isValid() == other.isValid()
-            && this->clipBoardMode() == other.clipBoardMode()
+            && (this->clipBoardMode() == other.clipBoardMode()
+                    || QlipperPreferences::Instance()->shouldSynchronizeClipboards()
+                    )
             && this->content() == other.content();
 }
 


### PR DESCRIPTION
..if we are synchronizing clipboards.

This avoids duplication of plain/text items in history, because in many
cases the text must be selected (set into PRIMARY) and then copied (set
into CLIPBOARD).