### PR TITLE
Fix build with ENABLE_NETWORK_CLIPBOARD_SHARING enabled.

### DIFF
--- a/src/qlippernetwork.h
+++ b/src/qlippernetwork.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define QLIPPERNETWORK_H
 
 #include <QtCore/QObject>
-#ifndef ENABLE_NETWORK_CLIPBOARD_SHARING
+#ifdef ENABLE_NETWORK_CLIPBOARD_SHARING
 #include <QtNetwork/QUdpSocket>
 #endif
 #include "qlippertypes.h"
@@ -38,7 +38,7 @@ public slots:
     void sendData(const ClipboardContent &value);
 
 private:
-#ifndef ENABLE_NETWORK_CLIPBOARD_SHARING
+#ifdef ENABLE_NETWORK_CLIPBOARD_SHARING
     QUdpSocket *m_socket;
     QString m_id;
 #endif

--- a/src/qlippertypes.h
+++ b/src/qlippertypes.h
@@ -2,7 +2,7 @@
 #define QLIPPERTYPES_H
 
 #include <QMetaType>
-
+#include <QHashIterator>
 
 typedef QHash<QString,QByteArray> ClipboardContent;
 typedef QHashIterator<QString,QByteArray> ClipboardContentIterator;


### PR DESCRIPTION
qlippernetwork.cpp expects network-related variables to be available if
ENABLE_NETWORK_CLIPBOARD_SHARING is defined, but qlippernetwork.h defined those
variables if ENABLE_NETWORK_CLIPBOARD_SHARING was *un*defined.

This also adds a missing include that is no longer available transitively via
QtNetwork/QUdpSocket.