### PR TITLE
Fixed issue 89: no matching function for call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ project(qlipper)
 
 set(QLIPPER_VERSION 5.1.1)
 
-option(ENABLE_NETWORK_CLIPBOARD_SHARING "Enables experimental network support for clipboard sharing" ON)
+option(ENABLE_NETWORK_CLIPBOARD_SHARING "Enables experimental network support for clipboard sharing" OFF)
 option(ENABLE_LXQT_AUTOSTART "Enables autostart for LXQt" OFF)
 option(USE_SYSTEM_QXT "Use system Qxt Library for global shortcuts; off for Qt5" OFF)
 
@@ -56,7 +56,6 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 find_package(Qt5Widgets "5.6" REQUIRED)
 find_package(Qt5LinguistTools REQUIRED)
-find_package(Qt5Network       REQUIRED)
 
 if (USE_SYSTEM_QXT)
     find_package(Qxt)
@@ -77,6 +76,7 @@ add_definitions(-DIS_CMAKE)
 add_definitions(-DQLIPPER_VERSION="${QLIPPER_VERSION}")
 if (ENABLE_NETWORK_CLIPBOARD_SHARING)
     add_definitions(-DENABLE_NETWORK_CLIPBOARD_SHARING)
+    find_package(Qt5Network REQUIRED)
 endif (ENABLE_NETWORK_CLIPBOARD_SHARING)
 
 
@@ -198,8 +198,13 @@ set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries( ${EXE_NAME}
     Qt5::Widgets
-    Qt5::Network
 )
+
+if (ENABLE_NETWORK_CLIPBOARD_SHARING)
+    target_link_libraries( ${EXE_NAME}
+        Qt5::Network
+    )
+endif(ENABLE_NETWORK_CLIPBOARD_SHARING)
 
 # single app and optional network features
 #target_link_libraries( ${EXE_NAME} ${QT_QTNETWORK_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,16 @@ project(qlipper)
 
 set(QLIPPER_VERSION 5.1.1)
 
-option(ENABLE_NETWORK_CLIPBOARD_SHARING "Enables experimental network support for clipboard sharing" OFF)
+option(ENABLE_NETWORK_CLIPBOARD_SHARING "Enables experimental network support for clipboard sharing" ON)
 option(ENABLE_LXQT_AUTOSTART "Enables autostart for LXQt" OFF)
 option(USE_SYSTEM_QXT "Use system Qxt Library for global shortcuts; off for Qt5" OFF)
 
 
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-
 find_package(Qt5Widgets "5.6" REQUIRED)
 find_package(Qt5LinguistTools REQUIRED)
+find_package(Qt5Network       REQUIRED)
 
 if (USE_SYSTEM_QXT)
     find_package(Qxt)
@@ -198,6 +198,7 @@ set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries( ${EXE_NAME}
     Qt5::Widgets
+    Qt5::Network
 )
 
 # single app and optional network features

--- a/src/qlippernetwork.cpp
+++ b/src/qlippernetwork.cpp
@@ -101,7 +101,12 @@ void QlipperNetwork::readData()
         ds >> c;
         qDebug() << "RECEIVED:" << c;
         QlipperItem item(QClipboard::Clipboard, QlipperItem::PlainText, c);
-        item.toClipboard();
+
+        // Manually create an action, and then pass it through.
+        QlipperItem::Actions action;
+        action |= QlipperItem::ToCurrent;
+        action |= QlipperItem::ToOther;
+        item.toClipboard(action);
     }
 #endif
 }


### PR DESCRIPTION
When building the project with networking, `item.toClipboard()`
is not passed with an action argument. I fixed it to do so.