### PR TITLE
display networking support as experimental

### DIFF
--- a/src/qlipperpreferencesdialog.ui
+++ b/src/qlipperpreferencesdialog.ui
@@ -313,7 +313,7 @@
        </rect>
       </property>
       <attribute name="label">
-       <string>Network</string>
+       <string>Network (Experimental)</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
        <item row="0" column="0" colspan="2">


### PR DESCRIPTION
As I summarized in #125, network is support is experimental, disabled by default at compile time, and the default preferences are disabled as well. I've found some other bugs (#126, #127, the latter of which is a major bug if it's correct) that certainly suggest that networking support isn't really in a good state. Therefore, it makes sense to warn the user that the support is indeed experimental.