### PR TITLE
Option to display history in reverse order close #149

### DIFF
--- a/src/qlippermodel.cpp
+++ b/src/qlippermodel.cpp
@@ -66,6 +66,13 @@ QlipperModel::~QlipperModel()
 
 void QlipperModel::resetPreferences()
 {
+    // If sticky items is empty, code will crash in Debug mode for unknown reason
+    // It will not crash in Release mode
+    if (m_sticky.count() == 0)
+    {
+        return;
+    }
+
     beginRemoveRows(QModelIndex(), 0, m_sticky.count() - 1);
     m_sticky.clear();
     endRemoveRows();

--- a/src/qlipperpreferences.cpp
+++ b/src/qlipperpreferences.cpp
@@ -223,6 +223,10 @@ bool QlipperPreferences::confirmOnClear() const
     return value("confirmClear", true).toBool();
 }
 
+bool QlipperPreferences::reverseOrder() const{
+    return value("reverseOrder", false).toBool();
+}
+
 bool QlipperPreferences::networkSend() const
 {
     return value("networkSend", false).toBool();

--- a/src/qlipperpreferences.h
+++ b/src/qlipperpreferences.h
@@ -55,6 +55,7 @@ public:
     bool platformExtensions() const;
     PSESynchronization synchronizePSE() const;
     bool clearItemsOnExit() const;
+    bool reverseOrder() const;
     bool synchronizeHistory() const;
     bool confirmOnClear() const;
 

--- a/src/qlipperpreferencesdialog.cpp
+++ b/src/qlipperpreferencesdialog.cpp
@@ -42,6 +42,7 @@ QlipperPreferencesDialog::QlipperPreferencesDialog(QWidget *parent) :
     synchronizePSE->setEnabled(pse);
     synchronizePSE->setCurrentIndex(s->synchronizePSE());
     clearItemsOnExit->setChecked(s->clearItemsOnExit());
+    reverseOrder->setChecked(s->reverseOrder());
     synchronizeHistory->setChecked(s->synchronizeHistory());
     confirmOnClear->setChecked(s->confirmOnClear());
 
@@ -106,6 +107,7 @@ void QlipperPreferencesDialog::accept()
     s->setValue("synchronizePSE", synchronizePSE->currentIndex());
     s->setValue("shortcut", shortcutWidget->keySequence().toString());
     s->setValue("clearItemsOnExit", clearItemsOnExit->isChecked());
+    s->setValue("reverseOrder", reverseOrder->isChecked());
     s->setValue("synchronizeHistory", synchronizeHistory->isChecked());
     s->setValue("confirmClear", confirmOnClear->isChecked());
 

--- a/src/qlipperpreferencesdialog.ui
+++ b/src/qlipperpreferencesdialog.ui
@@ -42,10 +42,17 @@
        <string>Preferences</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label">
+       <item row="10" column="0">
+        <widget class="QCheckBox" name="confirmOnClear">
          <property name="text">
-          <string>Clipboard Entries Count:</string>
+          <string>Confirm Clear History</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QKeySequenceWidget" name="shortcutWidget" native="true">
+         <property name="toolTip">
+          <string>Change global keyboard shortcut to invoke the menu on screen</string>
          </property>
         </widget>
        </item>
@@ -97,7 +104,14 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Clipboard Entries Count:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
         <widget class="QCheckBox" name="trimCheckBox">
          <property name="toolTip">
           <string>Useful for bigger text blocks copied for example from dummy terminals (minicom, etc.)</string>
@@ -107,21 +121,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="keyboardShortcutLabel">
-         <property name="text">
-          <string>Keyboard Shortcut:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QKeySequenceWidget" name="shortcutWidget" native="true">
-         <property name="toolTip">
-          <string>Change global keyboard shortcut to invoke the menu on screen</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Tray icon image:</string>
@@ -131,23 +131,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QToolButton" name="buttonIconImage">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-         <property name="popupMode">
-          <enum>QToolButton::InstantPopup</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="2">
+       <item row="6" column="0" colspan="2">
         <widget class="QCheckBox" name="platformExtensionsCheckBox">
          <property name="toolTip">
           <string>Use clipboard extensions (X11 Selections, OS X Find Buffer) when it's supported</string>
@@ -157,7 +141,27 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
+       <item row="9" column="0" colspan="2">
+        <widget class="QCheckBox" name="synchronizeHistory">
+         <property name="text">
+          <string>Synchronize history to storage instantly</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>96</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="7" column="0" colspan="2">
         <widget class="QComboBox" name="synchronizePSE">
          <item>
           <property name="text">
@@ -176,37 +180,43 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="0" colspan="2">
+       <item row="5" column="1">
+        <widget class="QToolButton" name="buttonIconImage">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="popupMode">
+          <enum>QToolButton::InstantPopup</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="keyboardShortcutLabel">
+         <property name="text">
+          <string>Keyboard Shortcut:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
         <widget class="QCheckBox" name="clearItemsOnExit">
          <property name="text">
           <string>Clear Items on Exit</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0" colspan="2">
-        <widget class="QCheckBox" name="synchronizeHistory">
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="reverseOrder">
+         <property name="toolTip">
+          <string>Newly copied data appears at end of the menu</string>
+         </property>
          <property name="text">
-          <string>Synchronize history to storage instantly</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0" colspan="2">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>96</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="confirmOnClear">
-         <property name="text">
-          <string>Confirm Clear History</string>
+          <string>Reverse order</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Look at "Unsolved concern" section, there's a change may break current stable release.

## QXT
`NO_QXT`

This code come with no Qxt library.  
So every code wrapped inside `#ifndef` will compile and run.
```
#ifndef NO_QXT
    // Code...
#endif
```

## System tray menu data
`qlippersystemtray.cpp`

`QlipperModel::clearHistory()` is at `qlippermodel.cpp`.  
When clearing history, a sample clipboard item will created like this:
```
ClipboardContent tmp;
tmp["text/plain"] = tr("Welcome to the Qlipper clipboard history applet").toUtf8();
QlipperItem item(QClipboard::Clipboard, QlipperItem::PlainText, tmp);

beginInsertRows(QModelIndex(), sticky_count, sticky_count);
m_dynamic.append(item);    // <- here
endInsertRows();
```
History is stored in `m_dynamic`, and `beginInsertRows` seems to be able to decide where to insert a clipboard item.

## System tray menu interface
`qlippersystemtray.cpp`

There is `m_shortcutMenu = new QMenuView();`, and related code to bind events.  
`m_shortcutMenu->setModel(m_model);` tells the menu where to get data.

`m_model` is created by `m_model = new QlipperModel(this);`

## How the data goes in system tray menu
`qlippermodel.cpp`

There are two types of data in system tray menu,  
one is `m_sticky` and another is `m_dynamic`.  
`m_dynamic` is the list that stores copied data,  
m_sticky can be ignored right now.

The program is hard coded to put data on top of the list by use  
`m_dynamic.prepend(item);`, to reverse the order, change this code to  
`m_sticky.append(item);`

## When it come to interface
In QCreator, double click to open `qlipperpreferencesdialog.ui`  
so "Check box" could be dragged from "Design" tab into setting interface.  
UI is layout based, multiple checkbox could stay inside same line,  
if thier width is smaller than certain amout.  
Otherwise, force two wide checkbox into same line,  
setting window width will increase.

## Get interface value in code
"qlipperpreferences.h"

There is "bool clearItemsOnExit() const;",  
write similar code aside to get user interface value.  
Typically a checkbox definiation looks like:
```
bool QlipperPreferences::clearItemsOnExit() const
{
    return value("clearItemsOnExit", false).toBool();
}
```
To use the function, call from other place:
```
auto clearItemsOnExit = QlipperPreferences::Instance()->clearItemsOnExit();
```

## Old data
`qlippermodel.cpp`

When copy content same as exist value, it will picked from data list,  
and put to top of the menu, then do font bold.  
By doing test, I should put this data to end of the menu,  
change bold position from `sticky_count + 1` to end of the menu.

The variable to determine a font is bold or not seems to be `m_currentIndex`.

The code to move data to top seems to be
```
void QlipperModel::setCurrentDynamic(int ix)
```

The code use erase to remove range of element at once instead of one by one.  

At the beginning, I guess this ensure that all old data will be deleted in signle event.  
But later the code use `-1` to determine how many data to be removed.  
I should update exist code to use ranged remove,  
but exist behavior is stable, best not to touch it.

Normal order:
```
beginRemoveRows(QModelIndex(), sticky_count + max_history - 1, sticky_count + m_dynamic.count() - 1);
m_dynamic.erase(m_dynamic.begin() + (max_history - 1), m_dynamic.end());
endRemoveRows();
```

Reverse order:
```
auto removeRowsBeginPosition = sticky_count;
auto removeRowsEndPosition = removeRowsBeginPosition + (m_dynamic.count() - max_history);
beginRemoveRows(QModelIndex(), removeRowsBeginPosition, removeRowsEndPosition);
auto dataBeginPosition = m_dynamic.begin();
auto dataEndPosition = dataBeginPosition + (m_dynamic.count() - max_history);
m_dynamic.erase(dataBeginPosition, dataEndPosition);
endRemoveRows();
```

## Move data
`qlippermodel.cpp`

The code with reverse order:
```
    if (reverseOrder)
    {
        auto m_dynamic_lastIndex = m_dynamic_count - 1;

        // move if not already on end
        if (ix != m_dynamic_lastIndex)
        {
            beginMoveRows(QModelIndex(), sticky_count + ix, sticky_count + ix, QModelIndex(), sticky_count + m_dynamic_count);
            m_dynamic.move(ix, m_dynamic_lastIndex);
            endMoveRows();
        }
    }
    else
    {
        // move if not already on top
        if (ix != 0)
        {
            beginMoveRows(QModelIndex(), sticky_count + ix, sticky_count + ix, QModelIndex(), sticky_count);
            m_dynamic.move(ix, 0);
            endMoveRows();
        }
    }
```
However, Qt API `beginMoveRows` seems to have a index start from 0,  
but the above code send `count` as parameter instead of `count - 1`.  
If I use `count - 1`, `endMoveRows()` will crash the program.  
I must assume that this code is based on `count` and have code hack in somewhere else.

## Bold it
`qlippermodel.cpp`

Look all references to `m_currentIndex`, one of them located at
```
    switch (role)
    {
    case Qt::DisplayRole:
        return list.at(row).displayRole();
    case Qt::DecorationRole:
        return list.at(row).decorationRole();
    case Qt::ToolTipRole:
        return list.at(row).tooltipRole();
    case Qt::FontRole:
        return m_currentIndex == index ? m_boldFont : m_normalFont;    // <- here
    }
```

This code not need to update.
To update it use `reverseOrder`:
```
if (reverseOrder)
{
    m_currentIndex = index(m_sticky.count() + m_dynamic_lastIndex);
    m_network->sendData(m_dynamic.at(m_dynamic_lastIndex).content());
}
```

## Unsolved concern

### Debug mode save setting crash
An unknwon exception will crash the program when the code runs to
```
void QlipperModel::resetPreferences()
{
    beginRemoveRows(QModelIndex(), 0, m_sticky.count() - 1);    // <- here
    m_sticky.clear();
    endRemoveRows();
    QList<QlipperItem> sticky = QlipperPreferences::Instance()->getStickyItems();
    beginInsertRows(QModelIndex(), 0, sticky.count() - 1);
    m_sticky = sticky;
    endInsertRows();
}
```
This crash only happens in Debug mode but not Release mode.  
A quick fix to avoid this suggested by code AI:
```
void QlipperModel::resetPreferences()
{
    // If sticky items is empty, code will crash in Debug mode for unknown reason
    // It will not crash in Release mode
    if (m_sticky.count() == 0){
        return;
    }

    beginRemoveRows(QModelIndex(), 0, m_sticky.count() - 1);
    m_sticky.clear();
    endRemoveRows();
    QList<QlipperItem> sticky = QlipperPreferences::Instance()->getStickyItems();
    beginInsertRows(QModelIndex(), 0, sticky.count() - 1);
    m_sticky = sticky;
    endInsertRows();
}
```