### PR TITLE
Fixed CMake errors and removed deprecated versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,9 @@
 #    It will copy all dependecies (libs/resources) into bundle tree
 # -------------------------------------------------------
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1.0)
-
+CMAKE_MINIMUM_REQUIRED(VERSION 3.11) 
+# from 3.1.0 to 3.6 because CMake now don't support backward compatibility for CMake < v3.5
+# and in future support for 3.11 is also getting dropped !
 project(qlipper)
 
 


### PR DESCRIPTION
# CMake Errors Fixed
## Error from `yay -S qlipper`
![image](https://github.com/user-attachments/assets/e4680ec1-0cb7-4a3e-8b7b-8cf31f280748)

